### PR TITLE
[Docs] README: Bind `C-c t` to Org Mode's keymap

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,7 +8,7 @@ You could download =ivy-todo= from Melpa, or add =ivy-todo.el= to your load-path
 
 #+BEGIN_SRC emacs-lisp
   (use-package ivy-todo :ensure t
-    :bind ("C-c t" . ivy-todo)
+    :bind (:map org-mode-map ("C-c t" . ivy-todo))
     :commands ivy-todo)
 #+END_SRC
 


### PR DESCRIPTION
This patch modifies the README showing how use-package allows the user
to bind keys to specific mode maps.  Key-combinations such as `C-c t`,
or `C-c <any single letter>` are reserved explicitly for the user and
no major or minor mode should rebind such keys; however, in this
instance the command `ivy-todo` cannot be bound to `C-c C-t`, and no
obvious alternative presents itself---maybe `C-c C-M-t`?  Org Mode
does not define it.

Regardless, this small change in documentation shows the user a way to
avoid conflicts he or she may have with existing `C-c t` bindings, as
I had, hence the impetus for the patch.

See-Also: https://www.gnu.org/software/emacs/manual/html_node/eintr/Keybindings.html#Keybindings

See the paragraph beginning with...

    As for the keybinding itself: C-c w.

...for details on how such bindings are reserved strictly for the user.

Signed-off-by: Eric James Michael Ritz <ericjmritz@yandex.com>